### PR TITLE
Restrict pcap to only ARP packets

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var int_array_to_hex = require('./helpers.js').int_array_to_hex;
 
 var create_session = function (arp_interface) {
     try {
-        var session = pcap.createSession(arp_interface);
+        var session = pcap.createSession(arp_interface, 'arp');
     } catch (err) {
         console.error(err);
         console.error("Failed to create pcap session: couldn't find devices to listen on.\n" + "Try running with elevated privileges via 'sudo'");


### PR DESCRIPTION
This fixes two problems:

1. My logs were filling up with messages like: `node_pcap: EthernetFrame() - Don't know how to decode ethertype 34958`.
1. According to the [pcap documentation](https://github.com/mranney/node_pcap/tree/d920204745c8b00ef4b7a3fe27d902b263cdb70f#dropped-packets), not filtering can lead to dropped packets. I haven't experienced this yet, but I am running this on an underpowered raspberry pi on a very busy network.
